### PR TITLE
upgrade from python 3.9 to 3.10 in Docker

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -53,6 +53,10 @@ jobs:
       - name: checkout vcell-solvers repo
         uses: actions/checkout@v4
 
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
       - name: Install Intel MacOS dependencies
         if: matrix.platform == 'macos-13'
         shell: bash
@@ -69,6 +73,7 @@ jobs:
           gcc --version
           gfortran --version
           cmake --version
+          python --version
           brew info boost
           brew info hdf5
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9.7-slim AS build
+FROM python:3.10.15-slim AS build
 
 RUN apt-get -y update && apt-get install -y apt-utils && \
     apt-get install -y -qq -o=Dpkg::Use-Pty=0 build-essential gfortran zlib1g-dev \
@@ -38,12 +38,12 @@ RUN $JAVA_HOME/bin/jlink \
          --output /javaruntime
 
 # Define base image and copy in jlink created minimal Java 17 environment
-FROM python:3.9.7-slim
+FROM python:3.10.15-slim
 ENV JAVA_HOME=/opt/java/openjdk
 ENV PATH="${JAVA_HOME}/bin:${PATH}"
 COPY --from=jre-build /javaruntime $JAVA_HOME
 
-# now we have Java 17 and Python 3.9
+# now we have Java 17 and Python 3.10.15 installed
 ENV DEBIAN_FRONTEND=noninteractive
 ENV LANG=en_US.UTF-8
 

--- a/Stochastic/CMakeLists.txt
+++ b/Stochastic/CMakeLists.txt
@@ -40,7 +40,7 @@ if (APPLE)
 	if (PROCESSOR_ARCHITECTURE STREQUAL "arm64")
 		link_directories("/opt/homebrew/lib")
 	else ()
-		link_directories("/usr/local/Cellar/hdf5/1.14.3_1/lib")
+		link_directories("/usr/local/lib")
 	endif()
 endif()
 


### PR DESCRIPTION
VCell is upgrading to 3.10, and this repo provides the base image for vcell-batch, so here we upgrade Python.